### PR TITLE
rm label

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
     <!--jumbotron-next-event-->
     <div class="jumbotron jumbotron-next-event">
       <div class="container text-center">
-        <h2><span class="label label-warning">Next Event</span> <span class="text-nowrap">Currently being planned</span></h2>
+        <h2>Next Event: Currently being planned</h2>
         <h3>
           <a href="https://github.com/nodeschool/sanfrancisco/issues/56">Join the conversation</a>
         </h3>


### PR DESCRIPTION
I propose getting rid of the warning label styling on "Next Event" for at least three reasons:

* Accessibility: The foreground text/background contrast is 1.9:1, well short of WCAG 2.0 AA and AAA requirements.
* Semantics: It is not a warning. It is not a label. Ergo, it should not be styled as a warning label.
* User Experience: The way it is styled now, "Next Event" looks like something clickable. It looks like a button. But it is not a button and it is not clickable. So it might be kind of frustrating for someone expecting to click "Next Event" to get details about the next event.

Without the styling, the text looks a bit plain, but I do think that's better. And with the styling removed, some more accessible, semantic, UX-enhancing style can be added.