### PR TITLE
add jekyll _site dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,6 @@ FakesAssemblies/
 
 # OSX
 .DS_Store
+
+# Jekyll
+_site


### PR DESCRIPTION
When I generate the site locally to preview, _site shows up in my `git status` output etc. Not anymore!