### PR TITLE
Added 'use strict' and 'npm run build' command

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,3 +1,4 @@
+'use strict';
 var handlebars = require('handlebars')
 var fs = require('fs')
 var path = require('path')

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "2.0.0",
   "description": "The NodeSchool SF chapter website.",
   "scripts": {
-    "start": "http-server ."
+    "start": "http-server .",
+    "build": "node build.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi @llkats, I got an error while building templates as:
```
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:139:18)
    at node.js:990:3
```
this should fix it,
and a `npm run build` command is provided to build the templates (replace: `node build.js`)