### PR TITLE
Add san francisco and port/host override

### DIFF
--- a/docs-src/index.mustache
+++ b/docs-src/index.mustache
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,target-densitydpi=device-dpi">
-    <title>NodeSchool SF</title>
+    <title>NodeSchool San Francisco</title>
     <link rel="stylesheet" href="./styles/index.css" />
   </head>
   <body>
@@ -19,7 +19,7 @@
               <img id="logo" class="header__logo" src="./images/nodeschool-sf-hexagon.svg" />
             <div class="header__logo-text">
               <div class="header__logo-text__nodeschool">NodeSchool</div>
-              <div class="header__logo-text__sf">SF</div>
+              <div class="header__logo-text__sf">San Francisco</div>
             </div>
             <nav class="header__social-links">
               <a href="https://twitter.com/nodeschoolsf">

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1,target-densitydpi=device-dpi">
-    <title>NodeSchool SF</title>
+    <title>NodeSchool San Francisco</title>
     <link rel="stylesheet" href="./styles/index.css" />
   </head>
   <body>
@@ -19,7 +19,7 @@
               <img id="logo" class="header__logo" src="./images/nodeschool-sf-hexagon.svg" />
             <div class="header__logo-text">
               <div class="header__logo-text__nodeschool">NodeSchool</div>
-              <div class="header__logo-text__sf">SF</div>
+              <div class="header__logo-text__sf">San Francisco</div>
             </div>
             <nav class="header__social-links">
               <a href="https://twitter.com/nodeschoolsf">

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "docs:watch:styles": "npm run docs:build:styles -- -w",
     "docs:watch:images": "chokidar docs-src/images/* -c 'npm run docs:build:images' --initial",
     "docs:watch:fonts": "chokidar docs-src/fonts/* -c 'npm run docs:build:fonts' --initial",
-    "docs:server": "static docs",
+    "docs:server": "static docs --port=${PORT:=8080} --host-address=${HOST:=127.0.0.1}",
     "docs:dev": "npm-run-all --parallel docs:watch docs:server"
   },
   "repository": {


### PR DESCRIPTION
This adds the word "San Francisco" to help with potential search engine results (aka finding us).

This also adds the ability to override the port and host for the dev server. Now we can:

```
$ PORT=8000 HOST=0.0.0.0 npm run docs:dev
```